### PR TITLE
Install php-bcmath on PHP 7.3 image

### DIFF
--- a/7.3/fpm/ubuntu/Dockerfile
+++ b/7.3/fpm/ubuntu/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
         php7.3-gd \
         php7.3-ctype \
         php7.3-zip \
+        php7.3-bcmath \
         git \
         unzip \
         make \


### PR DESCRIPTION
php-bcmath is required by ramsey/uuid package to generate ordered UUIDs. It is also required when using Laravel Telescope. I guess it is/will be quite common to use both of those in our projects.